### PR TITLE
Add role identifiers in the profile view

### DIFF
--- a/src/controllers/accounts/profile.js
+++ b/src/controllers/accounts/profile.js
@@ -43,7 +43,8 @@ profileController.get = async function (req, res, next) {
     if (meta.config['reputation:disabled']) {
         delete userData.reputation;
     }
-
+ 
+    userData.isInstructor = userData.accounttype === 'instructor';
     userData.posts = latestPosts; // for backwards compat.
     userData.latestPosts = latestPosts;
     userData.bestPosts = bestPosts;

--- a/src/controllers/accounts/profile.js
+++ b/src/controllers/accounts/profile.js
@@ -43,7 +43,7 @@ profileController.get = async function (req, res, next) {
     if (meta.config['reputation:disabled']) {
         delete userData.reputation;
     }
- 
+
     userData.isInstructor = userData.accounttype === 'instructor';
     userData.posts = latestPosts; // for backwards compat.
     userData.latestPosts = latestPosts;

--- a/themes/nodebb-theme-persona/templates/account/profile.tpl
+++ b/themes/nodebb-theme-persona/templates/account/profile.tpl
@@ -15,17 +15,20 @@
         </div>
         <!-- ENDIF banned -->
         <!-- ENDIF isAdminOrGlobalModeratorOrModerator -->
-
-        <!-- IF selectedGroup.length -->
+        
+        <!-- IF isTargetAdmin -->
         <div class="text-center">
-        {{{each selectedGroup}}}
-        <!-- IF selectedGroup.slug -->
-            <a href="{config.relative_path}/groups/{selectedGroup.slug}"><small class="label group-label inline-block" style="color:{selectedGroup.textColor};background-color: {selectedGroup.labelColor};"><!-- IF selectedGroup.icon --><i class="fa {selectedGroup.icon}"></i> <!-- ENDIF selectedGroup.icon -->{selectedGroup.userTitle}</small></a>
-        <!-- ENDIF selectedGroup.slug -->
-        {{{end}}}
+            <small class="label group-label inline-block" style="color: #ffffff; background-color: #000000;">Admin</small>
         </div>
+        <!-- ELSE -->
+        <div class="text-center">
+            <small class="label group-label inline-block" style="color: #ffffff; background-color: <!-- IF isInstructor -->#7aadff<!-- ELSE -->#ff7e79<!-- ENDIF isInstructor -->;">
+                {accounttype}
+            </small>
+        </div>
+        <!-- ENDIF isTargetAdmin -->
+        
         <br/>
-        <!-- ENDIF selectedGroup.length -->
 
         <!-- IF aboutme -->
         <span component="aboutme" class="text-center aboutme">{aboutmeParsed}</span>


### PR DESCRIPTION
Resolves #26. Displays the role of the user when viewing their profile.

### Testing

`npm run lint`
`npm run test`
`./nodebb build`

Successfully builds, no adding lint errors or failing test cases.

### UI Changes

![roleId-profile-view-image-admin](https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/55469793/0582d045-d0f1-4601-a6e8-e535418e1068) ![roleId-profile-view-image-student](https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/55469793/cdea383e-fcd8-4874-abcb-8d0c8cf57f21) ![roleId-profile-view-image-instructor](https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/55469793/96c3913f-64c4-4898-abdb-73afd0c84a5e)
