### PR TITLE
Add different colors for role identifiers

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -139,6 +139,11 @@ categoryController.get = async function (req, res, next) {
 
     analytics.increment([`pageviews:byCid:${categoryData.cid}`]);
 
+    categoryData.topic = categoryData.topics.map((topic) => {
+        topic.user.isInstructor = topic.user.accounttype === 'instructor';
+        return topic;
+    });
+
     res.render('category', categoryData);
 };
 

--- a/src/controllers/popular.js
+++ b/src/controllers/popular.js
@@ -26,5 +26,11 @@ popularController.get = async function (req, res, next) {
     if (req.loggedIn) {
         data.rssFeedUrl += `?${feedQs}`;
     }
+
+    data.topic = data.topics.map((topic) => {
+        topic.user.isInstructor = topic.user.accounttype === 'instructor';
+        return topic;
+    });
+
     res.render('popular', data);
 };

--- a/src/controllers/recent.js
+++ b/src/controllers/recent.js
@@ -117,6 +117,10 @@ const get = (req, res, next) => __awaiter(void 0, void 0, void 0, function* () {
     if (!data) {
         return next();
     }
+    data.topics = data.topics.map((topic) => {
+        topic.user.isInstructor = topic.user.accounttype === 'instructor';
+        return topic;
+    });
     res.render('recent', data);
 });
 exports.get = get;

--- a/src/controllers/recent.ts
+++ b/src/controllers/recent.ts
@@ -8,7 +8,7 @@ import meta from '../meta';
 import helpers from './helpers';
 import pagination from '../pagination';
 import privileges from '../privileges';
-import { Breadcrumbs, Pagination } from '../types';
+import { Breadcrumbs, Pagination, TopicObject } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const relative_path: string = nconf.get('relative_path');
@@ -34,6 +34,7 @@ type TermType = {
 }
 
 type RecentDataType = {
+    topics: TopicObject[],
     title: string,
     breadcrumbs: Breadcrumbs,
     canPost: boolean,
@@ -154,5 +155,11 @@ export const get = async (req: RecentRequest, res: Response<object, Locals>, nex
     if (!data) {
         return next();
     }
+
+    data.topics = data.topics.map((topic) => {
+        topic.user.isInstructor = topic.user.accounttype === 'instructor';
+        return topic;
+    });
+
     res.render('recent', data);
 };

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -64,6 +64,11 @@ unreadController.get = async function (req, res) {
     data.filters = helpers.buildFilters(baseUrl, filter, req.query);
     data.selectedFilter = data.filters.find(filter => filter && filter.selected);
 
+    data.topic = data.topics.map((topic) => {
+        topic.user.isInstructor = topic.user.accounttype === 'instructor';
+        return topic;
+    });
+
     res.render('unread', data);
 };
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -23,6 +23,7 @@ export type UserObjectSlim = {
   lastonlineISO: string;
   banned_until: number;
   banned_until_readable: string;
+  isInstructor: boolean;
 };
 
 export type UserObjectACP = UserObjectSlim & {

--- a/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topics_list.tpl
@@ -65,7 +65,7 @@
                     &bull; 
                     <a href="<!-- IF topics.user.userslug -->{config.relative_path}/user/{topics.user.userslug}<!-- ELSE -->#<!-- ENDIF topics.user.userslug -->">{topics.user.displayname}</a> 
                     &bull; 
-                    <small class="label group-label inline-block" style="color:#ffffff;background-color: #7aadff;">{topics.user.accounttype}</small>
+                    <small class="label group-label inline-block" style="color:#ffffff;background-color: <!-- IF topics.user.isInstructor -->#7aadff<!-- ELSE -->#ff7e79<!-- ENDIF topics.user.isInstructor -->;">{topics.user.accounttype}</small>
                 </small>
                 <small class="visible-xs-inline">
                     <!-- IF topics.teaser.timestamp -->


### PR DESCRIPTION
Resolves #30. Changes the colors between instructors and students.

### Testing

`npm run lint`
`npm run test`
`./nodebb build`

Successfully builds, no adding lint errors or failing test cases.

### UI Changes

#### Previous
![role_id_color](https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/55469793/977da5f1-106b-480e-b5fb-f6bc63bed357)
#### Current
![roleId-color-change-image](https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/55469793/4634ad4a-c2b4-4d96-ac31-f7b972575906)
