### PR TITLE
install retire vulnerability analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
         "prompt": "1.3.0",
         "request": "2.88.2",
         "request-promise-native": "1.0.9",
+        "retire": "^4.3.4",
         "rimraf": "3.0.2",
         "rss": "1.2.2",
         "sanitize-html": "2.8.1",


### PR DESCRIPTION
### Summary 
Retire is a static analysis tool designed to evaluate potential code vulnerabilities by identifying libraries and versions with known vulnerabilities.

### Installed 
`npm install retire`

### Usage 
`./node_modules/.bin/retire` 

### Text File of Terminal Output
[retirejs-output.txt](https://github.com/CMU-313/fall23-nodebb-pittbegels/files/13194156/retirejs-output.txt)

### Image of Partial Terminal Output
<img width="1096" alt="Screenshot 2023-10-27 at 9 37 09 PM" src="https://github.com/CMU-313/fall23-nodebb-pittbegels/assets/98433977/14f4289d-717a-4fee-8789-c8e8a1ecb62c">
